### PR TITLE
K8S-468 Split the pool update from the db sync

### DIFF
--- a/tasks/designate_pool_setup.yml
+++ b/tasks/designate_pool_setup.yml
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Perform a Designate DB sync
-  command: "{{ designate_bin }}/designate-manage database sync"
+- name: Perform a Designate DNS pools update
+  command: "{{ designate_bin }}/designate-manage pool update"
   become: yes
   become_user: "{{ designate_system_user_name }}"
   changed_when: false
+  when: designate_pools_yaml is defined
   notify: Restart designate services
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,10 +41,15 @@
   tags:
     - designate-install
 
+- include: designate_db_setup.yml
+  when: inventory_hostname == groups['designate_all'][0]
+  tags:
+    - designate-install
+
 - name: Flush handlers
   meta: flush_handlers
 
-- include: designate_db_setup.yml
+- include: designate_pool_setup.yml
   when: inventory_hostname == groups['designate_all'][0]
   tags:
     - designate-install


### PR DESCRIPTION
Updated the location of the flush_handlers meta to restart the services before the pool update. This required breaking out the pool update task to a separate playbook that is run after the handlers have been run. 