### PR TITLE
K8S-552: Update newton branch tag

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,7 @@ designate_pip_package_state: "latest"
 
 ## The git source/branch
 designate_git_repo: https://git.openstack.org/openstack/designate
-designate_git_install_branch: stable/newton
+designate_git_install_branch: newton-eol
 
 # Developer mode is used for role functional testing and allows the role
 # to build an environment directly from a git source without the presence


### PR DESCRIPTION
Since the newton branch was eol on 10-11-2017 we need to update the tag
from stable/newton to newton-eol. This will allow us to continue to
use the newton branch for our deployment.