### PR TITLE
k8s-952: Update pip install options to use isolated mode

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -148,6 +148,8 @@ designate_pip_packages:
   - pycrypto
   - warlock
 
+pip_install_options: "--isolated"
+
 designate_central_init_overrides: {}
 designate_worker_init_overrides: {}
 designate_producer_init_overrides: {}


### PR DESCRIPTION
I think it would be better to define the pip install options into the defaults variables file instead of hard-coding the option in the designate_install.yml playbook. This should add in the --isolated option during the pip build plays